### PR TITLE
Ignore non-zero return codes from executing git

### DIFF
--- a/git_secrets/secrets/git.py
+++ b/git_secrets/secrets/git.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 import subprocess
+from subprocess import CalledProcessError
 from unidiff import PatchSet
 import os
 
@@ -32,4 +33,12 @@ def get_hooks_directory() -> Optional[str]:
 
 
 def _run_git_with_arguments(arguments: List[str]) -> str:
-    return subprocess.check_output(['git'] + arguments, encoding='utf-8').strip()
+    try:
+        output = subprocess.check_output(['git'] + arguments, encoding='utf-8', stderr=subprocess.PIPE).strip()
+    except CalledProcessError as exception:
+        if exception.output != '':
+            output = exception.output
+        else:
+            output = exception.stderr
+
+    return output

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_requirements():
 
 setup(
     name='qpp-git-secrets',
-    version='1.1.0',
+    version='1.1.1',
     author='halprin',
     author_email='me@halprin.io',
     description='Git without secrets',

--- a/tests/secrets/git_test.py
+++ b/tests/secrets/git_test.py
@@ -1,0 +1,9 @@
+from git_secrets.secrets import git
+
+
+def test__run_git_with_arguments_good():
+    assert git._run_git_with_arguments(['version']).startswith('git version')
+
+
+def test__run_git_with_arguments_bad():
+    assert 'is not a git command' in git._run_git_with_arguments(['not_a_real_git_sub_command'])


### PR DESCRIPTION
- Ignore non-zero return codes from executing `git`.
- Update version to `1.1.1`.